### PR TITLE
Added matching extern C closing bracket

### DIFF
--- a/bmi3.h
+++ b/bmi3.h
@@ -1641,4 +1641,8 @@ int8_t bmi3_get_acc_gyr_off_gain_reset(uint8_t *acc_off_gain_reset, uint8_t *gyr
  */
 int8_t bmi3_set_acc_gyr_off_gain_reset(uint8_t acc_off_gain_reset, uint8_t gyr_off_gain_reset, struct bmi3_dev *dev);
 
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+
 #endif /* End of _BMI3_H */

--- a/bmi323.h
+++ b/bmi323.h
@@ -1713,4 +1713,8 @@ int8_t bmi323_get_acc_gyr_off_gain_reset(uint8_t *acc_off_gain_reset, uint8_t *g
  */
 int8_t bmi323_set_acc_gyr_off_gain_reset(uint8_t acc_off_gain_reset, uint8_t gyr_off_gain_reset, struct bmi3_dev *dev);
 
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+
 #endif /* End of _BMI323_H */


### PR DESCRIPTION
Hey there! 👋 

### Problem
I wanted to use the bmi323 driver in a CPP project and got an unmatched bracket compiler error. Figured that it is because of the missing `extern "C" {` closing bracket from the end of the file.

```
.././drivers/bmi323/bmi323.h:54:1: note: 'extern "C"' linkage started here
   54 | extern "C" {
      | ^~~~~~~~~~
../src/SensorController.cpp:263:2: error: expected '}' at end of input
  263 | }
      |  ^
.././drivers/bmi323/bmi323.h:54:12: note: to match this '{'
   54 | extern "C" {
      |            ^
```

### Solution
I have added the closing brackets to the end of the header files for both `bmi3.h` and `bmi323.h` which fixed the compiler errors. I guess the intention was to enclose all function declarations, but let me know if it should be moved. 🙂 

Cheers 